### PR TITLE
Upgrade docker version of Elixir to 1.4.1

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM msaraiva/elixir-dev
+FROM nebo15/alpine-elixir:1.4.1-r0
 MAINTAINER DrPandemic
 
 ENV REFRESHED_AT 2017-01-27
@@ -16,7 +16,7 @@ ENV MIX_ENV prod
 
 WORKDIR /build
 
-RUN mix local.hex
+RUN mix local.hex --force
 RUN mix deps.get --only prod
 RUN mix compile
 RUN echo y | mix release.clean --implode


### PR DESCRIPTION
Changed the base Repo for the docker image in order to use Elixir 1.4.1 
(this was required since the version needed for the project was set to ~> 1.4)

The new repo is nebo15/alpine-elixir:1.4.1-r0

I also force the installation when we execute "mix local.hex", because sometime user interaction is needed and we aren't in an interactive mode.