### PR TITLE
Better timestamps

### DIFF
--- a/lib/masdb/time.ex
+++ b/lib/masdb/time.ex
@@ -1,9 +1,0 @@
-defmodule Masdb.Time do
-  # http://erlang.org/doc/apps/erts/time_correction.html
-  def get_timestamp do
-    {
-      System.monotonic_time(),
-      System.unique_integer([:monotonic])
-    }
-  end
-end

--- a/lib/masdb/timestamp.ex
+++ b/lib/masdb/timestamp.ex
@@ -1,0 +1,16 @@
+defmodule Masdb.Timestamp do
+  @type t :: %Masdb.Timestamp{
+    time: integer,
+    unique_integer: integer
+  }
+  @enforce_keys [:time, :unique_integer]
+  defstruct [:time, :unique_integer]
+
+  # http://erlang.org/doc/apps/erts/time_correction.html
+  def get_timestamp do
+    %Masdb.Timestamp{
+      time: System.monotonic_time(),
+      unique_integer: System.unique_integer([:monotonic])
+    }
+  end
+end

--- a/test/timestamp_test.exs
+++ b/test/timestamp_test.exs
@@ -1,11 +1,14 @@
-defmodule TimeTest do
+defmodule TimestampTest do
   use PowerAssert
-  import Masdb.Time
+  import Masdb.Timestamp
 
   test "returns a timestamp" do
     t0 = get_timestamp()
+    Process.sleep(5)
     t1 = get_timestamp()
 
     assert t0 <= t1
+    assert t0 == t0
+    assert t1 >= t0
   end
 end


### PR DESCRIPTION
I was about to modify how the schema could be overridden, but you made me realize this **should** not happen. So I just kept the new timestamp code.