### PR TITLE
Adding a schema is calculated in another thread

### DIFF
--- a/lib/masdb/register_server.ex
+++ b/lib/masdb/register_server.ex
@@ -41,7 +41,8 @@ defmodule Masdb.Register.Server do
       GenServer.reply(from, :ok)
       {:noreply, %Masdb.Register{state | schemas: [schema | state.schemas]}}
     else
-      {:reply, :did_not_receive_quorum, state}
+      GenServer.reply(from, :did_not_receive_quorum)
+      {:noreply, state}
     end
   end
 

--- a/lib/masdb/register_server.ex
+++ b/lib/masdb/register_server.ex
@@ -9,6 +9,10 @@ defmodule Masdb.Register.Server do
     GenServer.call(__MODULE__, {:add_schema, schema})
   end
 
+  def received_add_schema(%Masdb.Schema{} = schema, nodes, answers, from) do
+    GenServer.cast(__MODULE__, {:received_add_schema, schema, nodes, answers, from})
+  end
+
   def remote_add_schema(%Masdb.Schema{} = schema) do
     GenServer.call(__MODULE__, {:remote_add_schema, schema})
   end
@@ -18,21 +22,26 @@ defmodule Masdb.Register.Server do
   end
 
   # private
-  def handle_call({:add_schema, schema}, _, state) do
+  def handle_call({:add_schema, schema}, from, state) do
     case Masdb.Register.validate_new_schema(state.schemas, schema) do
       :ok ->
-        nodes = Masdb.Node.Connection.list()
-        if Masdb.Node.Communication.has_quorum?(nodes, Masdb.Node.DistantSupervisor.query_remote_node(
-                  nodes,
-                  Masdb.Register.Server,
-                  :remote_add_schema,
-                  [schema])) do
-              {:reply, :ok, %Masdb.Register{state | schemas: [schema | state.schemas]}}
-            else
-              {:reply, :did_not_receive_quorum, state}
-            end
+        spawn fn ->
+          nodes = Masdb.Node.Connection.list()
+          a = Masdb.Node.DistantSupervisor.query_remote_node(nodes, Masdb.Register.Server, :remote_add_schema, [schema])
+          Masdb.Register.Server.received_add_schema(schema, nodes, a, from)
+        end
+        {:noreply, state}
 
       error -> {:reply, error, state}
+    end
+  end
+
+  def handle_cast({:received_add_schema, schema, nodes, answers, from}, state) do
+    if Masdb.Node.Communication.has_quorum?(nodes, answers) do
+      GenServer.reply(from, :ok)
+      {:noreply, %Masdb.Register{state | schemas: [schema | state.schemas]}}
+    else
+      {:reply, :did_not_receive_quorum, state}
     end
   end
 


### PR DESCRIPTION
This way the GenServer is not blocked when processing a new schema. This way, multiple adds at the same time on different nodes won't deadlock the system.

I would really like to be able to test this but I have no clue how. I'm unable to find articles about that.

The next step will be to save schema being added to prevent 2 nodes from trying to add the same schema.