### PR TITLE
Lets older schema overwrite newer schema

### DIFF
--- a/lib/masdb/register_server.ex
+++ b/lib/masdb/register_server.ex
@@ -41,7 +41,8 @@ defmodule Masdb.Register.Server do
       GenServer.reply(from, :ok)
       {:noreply, %Masdb.Register{state | schemas: [schema | state.schemas]}}
     else
-      {:reply, :did_not_receive_quorum, state}
+      GenServer.reply(from, :did_not_receive_quorum)
+      {:noreply, state}
     end
   end
 

--- a/lib/masdb/register_server.ex
+++ b/lib/masdb/register_server.ex
@@ -23,6 +23,7 @@ defmodule Masdb.Register.Server do
 
   # private
   def handle_call({:add_schema, schema}, from, state) do
+    schema = Masdb.Schema.update_timestamp(schema)
     case Masdb.Register.validate_new_schema(state.schemas, schema) do
       :ok ->
         spawn fn ->
@@ -36,16 +37,6 @@ defmodule Masdb.Register.Server do
     end
   end
 
-  def handle_cast({:received_add_schema, schema, nodes, answers, from}, state) do
-    if Masdb.Node.Communication.has_quorum?(nodes, answers) do
-      GenServer.reply(from, :ok)
-      {:noreply, %Masdb.Register{state | schemas: [schema | state.schemas]}}
-    else
-      GenServer.reply(from, :did_not_receive_quorum)
-      {:noreply, state}
-    end
-  end
-
   def handle_call({:remote_add_schema, schema}, _, state) do
     case Masdb.Register.validate_new_schema(state.schemas, schema) do
       :ok -> {:reply, :ok, %Masdb.Register{state | schemas: [schema | state.schemas]}}
@@ -55,5 +46,15 @@ defmodule Masdb.Register.Server do
 
   def handle_call(:get_schemas, _, %{schemas: schemas} = state) do
     {:reply, schemas, state}
+  end
+
+  def handle_cast({:received_add_schema, schema, nodes, answers, from}, state) do
+    if Masdb.Node.Communication.has_quorum?(nodes, answers) do
+      GenServer.reply(from, :ok)
+      {:noreply, %Masdb.Register{state | schemas: [schema | state.schemas]}}
+    else
+      GenServer.reply(from, :did_not_receive_quorum)
+      {:noreply, state}
+    end
   end
 end

--- a/lib/masdb/register_server.ex
+++ b/lib/masdb/register_server.ex
@@ -9,6 +9,10 @@ defmodule Masdb.Register.Server do
     GenServer.call(__MODULE__, {:add_schema, schema})
   end
 
+  def received_add_schema(%Masdb.Schema{} = schema, nodes, answers, from) do
+    GenServer.cast(__MODULE__, {:received_add_schema, schema, nodes, answers, from})
+  end
+
   def remote_add_schema(%Masdb.Schema{} = schema) do
     GenServer.call(__MODULE__, {:remote_add_schema, schema})
   end
@@ -18,21 +22,26 @@ defmodule Masdb.Register.Server do
   end
 
   # private
-  def handle_call({:add_schema, schema}, _, state) do
+  def handle_call({:add_schema, schema}, from, state) do
     case Masdb.Register.validate_new_schema(state.schemas, schema) do
       :ok ->
-        nodes = Masdb.Node.Connection.list()
-        if Masdb.Node.Communication.has_quorum?(nodes, Masdb.Node.DistantSupervisor.query_remote_node(
-                  nodes,
-                  Masdb.Register.Server,
-                  :remote_add_schema,
-                  [schema])) do
-              {:reply, :ok, %Masdb.Register{state | schemas: [schema | state.schemas]}}
-            else
-              {:reply, :did_not_receive_quorum, state}
-            end
+        spawn fn ->
+          nodes = Masdb.Node.Connection.list()
+          a = Masdb.Node.DistantSupervisor.query_remote_node(nodes, Masdb.Register.Server, :remote_add_schema, [schema])
+          Masdb.Register.Server.received_add_schema(schema, nodes, a, from)
+        end
+        {:noreply, state}
 
       error -> {:reply, error, state}
+    end
+  end
+
+  def handle_cast({:received_add_schema, schema, nodes, answers, from}, state) do
+    if Masdb.Node.Communication.has_quorum?(nodes, answers) do
+      GenServer.reply(from, :ok)
+      {:noreply, %Masdb.Register{state | schemas: [schema | state.schemas]}}
+    else
+      {:reply, :did_not_receive_quorum, state}
     end
   end
 

--- a/lib/masdb/schema.ex
+++ b/lib/masdb/schema.ex
@@ -9,10 +9,11 @@ defmodule Masdb.Schema do
   @type t :: %Masdb.Schema{
     name: String.t,
     columns: list(Masdb.Schema.Column.t),
-    replication_factor: integer
+    replication_factor: integer,
+    creation_time: Masdb.Timestamp.t
   }
   @enforce_keys [:name, :replication_factor]
-  defstruct [:name, :replication_factor, columns: []]
+  defstruct [:name, :replication_factor, columns: [], creation_time: Masdb.Timestamp.get_timestamp()]
 
   def validate(%Masdb.Schema{replication_factor: f}) when f < 0 do
     :replication_factor_limits
@@ -20,5 +21,9 @@ defmodule Masdb.Schema do
 
   def validate(%Masdb.Schema{}) do
     :ok
+  end
+
+  def update_timestamp(%Masdb.Schema{} = schema) do
+    %{schema | creation_time: Masdb.Timestamp.get_timestamp}
   end
 end

--- a/test/register_test.exs
+++ b/test/register_test.exs
@@ -22,4 +22,15 @@ defmodule ResgisterTest do
       %Masdb.Schema{name: "foo", replication_factor: -1}
     ) != :ok
   end
+
+  test "tests that an older schema could overwrite a schema" do
+    d0 = Masdb.Timestamp.get_timestamp()
+    Process.sleep 1
+    d1 = Masdb.Timestamp.get_timestamp()
+
+    assert validate_new_schema(
+      [%Masdb.Schema{name: "foo", replication_factor: 1, creation_time: d1}],
+      %Masdb.Schema{name: "foo", replication_factor: 1, creation_time: d0}
+    ) == :ok
+  end
 end

--- a/test/register_test.exs
+++ b/test/register_test.exs
@@ -29,8 +29,8 @@ defmodule ResgisterTest do
     d1 = Masdb.Timestamp.get_timestamp()
 
     assert validate_new_schema(
-      [%Masdb.Schema{name: "foo", replication_factor: 1, creation_time: d1}],
-      %Masdb.Schema{name: "foo", replication_factor: 1, creation_time: d0}
+      [%Masdb.Schema{name: "foo", replication_factor: 1, creation_time: d1, columns: [%Masdb.Schema.Column{is_pk: true,  name: "c1", type: :int}]}],
+      %Masdb.Schema{name: "foo", replication_factor: 1, creation_time: d0, columns: [%Masdb.Schema.Column{is_pk: true,  name: "c1", type: :int}]}
     ) == :ok
   end
 end

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -7,4 +7,12 @@ defmodule SchemaTest do
     assert validate(%Masdb.Schema{name: "foo", replication_factor: 1}) == :ok
     assert validate(%Masdb.Schema{name: "foo", replication_factor: 0}) == :ok
   end
+
+  test "can update timestamp" do
+    schema0 = %Masdb.Schema{name: "foo", replication_factor: 1}
+    Process.sleep 1
+    schema1 = Masdb.Schema.update_timestamp(schema0)
+
+    assert schema0.creation_time != schema1.creation_time
+  end
 end


### PR DESCRIPTION
This lets older schema overwrite a newer schema. We can do this since our schemas are immutable. I'm not 100% sure, but I think this could happen when a new schema is denied. 