### PR TITLE
Docker js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk — update upgrade && \
  rm -rf /var/cache/apk/*
 
 ARG APP
-ARG VERSION
+ARG MODE=foreground
 
 ENV MIX_ENV prod
 ENV PORT 4000
@@ -23,4 +23,8 @@ WORKDIR /$APP
 
 EXPOSE $PORT
 
-CMD trap exit TERM; bin/$APP foreground & wait
+RUN echo "NXKNQHHHUPLJYRMTNESR" > /root/.erlang.cookie
+RUN chmod 600 /root/.erlang.cookie
+RUN epmd -daemon
+
+CMD trap exit TERM; bin/$APP $MODE & wait

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM msaraiva/elixir
+FROM nebo15/alpine-elixir:1.4.1-r0
 MAINTAINER DrPandemic
 
-ENV REFRESHED_AT 2017–01–28
+ENV REFRESHED_AT 2017–03–23
 ENV HOME /root
 
 # Upgrade all packages

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,7 +1,7 @@
 FROM nebo15/alpine-elixir:1.4.1-r0
 MAINTAINER DrPandemic
 
-ENV REFRESHED_AT 2017-01-27
+ENV REFRESHED_AT 2017-03-23
 ENV HOME /root
 
 # Upgrade all packages and install needed packages

--- a/bin/Windows/build_windows.bat
+++ b/bin/Windows/build_windows.bat
@@ -1,9 +1,6 @@
 @echo off
-REM Kill and delete the VM-MasDB machine, recreates it and start it again
+REM Creates the masdb.app images inside a builder.app container
 cd ../../
-docker kill VM-MasDB
-docker rm VM-MasDB
-docker build -t masdb.app -f Dockerfile.build --build-arg APP=masdb .
-docker create --name "VM-MasDB" --rm -i masdb.app
-docker start VM-MasDB
-docker exec -d VM-MasDB epmd -daemon
+docker build -t builder.app -f Dockerfile.build --build-arg APP=app .
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock builder.app docker build -t masdb.app -f Dockerfile --build-arg APP=masdb --build-arg MODE=foreground .
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock builder.app docker build -t masdb-console.app -f Dockerfile --build-arg APP=masdb --build-arg MODE=console .

--- a/bin/Windows/docker_refresh.bat
+++ b/bin/Windows/docker_refresh.bat
@@ -1,4 +1,0 @@
-@echo off
-REM After copying the build directory, simply run recompile() to refresh the VM
-cd ../..
-docker cp . VM-MasDB:/build

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-docker build -t buildhelper.app -f Dockerfile.build --build-arg APP=masdb .
-docker run -v /var/run/docker.sock:/var/run/docker.sock buildhelper.app docker build -t build.app -f Dockerfile --build-arg APP=masdb --build-arg VERSION=0.1.0 .
+docker build -t builder.app -f Dockerfile.build --build-arg APP=app .
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock builder.app docker build -t masdb.app -f Dockerfile --build-arg APP=masdb --build-arg MODE=foreground .


### PR DESCRIPTION
Update the docker and the build scripts so the foreground mode is working
The console mode seems to start, but it close instantly...

To run the docker machine execute:
 docker run --env-file ./.env masdb.app bin/masdb foreground

It's also available on the dockerhub: docker run --env-file ./default.env samdus/masdb-app bin/masdb foreground