### PR TITLE
Init before sync

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -16,6 +16,10 @@ config :masdb,
   gossip_interval: 2_000,
   gossip_size: 2
 
+config :logger,
+  backends: [:console],
+  compile_time_purge_level: :info
+
 # You can configure for your application as:
 #
 #     config :masdb, key: :value

--- a/lib/masdb/communication.ex
+++ b/lib/masdb/communication.ex
@@ -3,6 +3,17 @@ defmodule Masdb.Node.Communication do
     Enum.take_random(nodes, size || quorum_size(length(nodes)))
   end
 
+  def select_with_rest(nodes, size) do
+    selected = select_quorum(nodes, size)
+    {selected, remove_all(nodes, selected)}
+  end
+
+  defp remove_all(nodes, selected) do
+    Enum.reject(nodes, fn n ->
+      Enum.find(selected, &(&1 == n))
+    end)
+  end
+
   def quorum_size(0), do: 0
   def quorum_size(size) do
     Integer.floor_div(size, 2) + 1

--- a/lib/masdb/distant_supervisor.ex
+++ b/lib/masdb/distant_supervisor.ex
@@ -11,27 +11,27 @@ defmodule Masdb.Node.DistantSupervisor do
     Enum.find(tasks, fn t -> elem(t, 1).ref == ref end)
   end
 
-  def query_remote_node_until(nodes, module, fun, params, min, answers \\ [], opts \\ [])
-  def query_remote_node_until(_, _, _, _, min, answers, _)
+  def query_remote_nodes_until(nodes, module, fun, params, min, answers \\ [], opts \\ [])
+  def query_remote_nodes_until(_, _, _, _, min, answers, _)
   when length(answers) >= min do
     answers
   end
 
-  def query_remote_node_until(nodes, _, _, _, min, answers, _)
+  def query_remote_nodes_until(nodes, _, _, _, min, answers, _)
   when length(nodes) + length(answers) < min do
     :not_enough_nodes
   end
 
-  def query_remote_node_until(nodes, module, fun, params, min, _, opts) do
+  def query_remote_nodes_until(nodes, module, fun, params, min, _, opts) do
     {nodes, rest} = Masdb.Node.Communication.select_with_rest(nodes, min)
     answers =
       Enum.map(nodes, &spawn_query(&1, module, fun, params))
       |> await_results(opts)
 
-    query_remote_node_until(rest, module, fun, params, min, opts, answers)
+    query_remote_nodes_until(rest, module, fun, params, min, opts, answers)
   end
 
-  def query_remote_node(nodes, module, fun, params, opts \\ []) do
+  def query_remote_nodes(nodes, module, fun, params, opts \\ []) do
     nodes
     |> Enum.map(&spawn_query(&1, module, fun, params))
     |> await_results(opts)

--- a/lib/masdb/distant_supervisor.ex
+++ b/lib/masdb/distant_supervisor.ex
@@ -12,7 +12,6 @@ defmodule Masdb.Node.DistantSupervisor do
   end
 
   def query_remote_node_until(nodes, module, fun, params, min, answers \\ [], opts \\ [])
-
   def query_remote_node_until(_, _, _, _, min, answers, _)
   when length(answers) >= min do
     answers

--- a/lib/masdb/distant_supervisor.ex
+++ b/lib/masdb/distant_supervisor.ex
@@ -11,6 +11,9 @@ defmodule Masdb.Node.DistantSupervisor do
     Enum.find(tasks, fn t -> elem(t, 1).ref == ref end)
   end
 
+  def query_remote_node_until(nodes, module, fun, params, min, opts \\ []) do
+  end
+
   def query_remote_node(nodes, module, fun, params, opts \\ []) do
     nodes
     |> Enum.map(&spawn_query(&1, module, fun, params))

--- a/lib/masdb/distant_supervisor.ex
+++ b/lib/masdb/distant_supervisor.ex
@@ -11,7 +11,25 @@ defmodule Masdb.Node.DistantSupervisor do
     Enum.find(tasks, fn t -> elem(t, 1).ref == ref end)
   end
 
-  def query_remote_node_until(nodes, module, fun, params, min, opts \\ []) do
+  def query_remote_node_until(nodes, module, fun, params, min, answers \\ [], opts \\ [])
+
+  def query_remote_node_until(_, _, _, _, min, answers, _)
+  when length(answers) >= min do
+    answers
+  end
+
+  def query_remote_node_until(nodes, _, _, _, min, answers, _)
+  when length(nodes) + length(answers) < min do
+    :not_enough_nodes
+  end
+
+  def query_remote_node_until(nodes, module, fun, params, min, _, opts) do
+    {nodes, rest} = Masdb.Node.Communication.select_with_rest(nodes, min)
+    answers =
+      Enum.map(nodes, &spawn_query(&1, module, fun, params))
+      |> await_results(opts)
+
+    query_remote_node_until(rest, module, fun, params, min, opts, answers)
   end
 
   def query_remote_node(nodes, module, fun, params, opts \\ []) do

--- a/lib/masdb/distant_supervisor.ex
+++ b/lib/masdb/distant_supervisor.ex
@@ -12,23 +12,28 @@ defmodule Masdb.Node.DistantSupervisor do
   end
 
   def query_remote_nodes_until(nodes, module, fun, params, min, answers \\ [], opts \\ [])
+  # enough responses
   def query_remote_nodes_until(_, _, _, _, min, answers, _)
   when length(answers) >= min do
-    answers
+    {:ok, answers}
   end
 
+  # even with all nodes left, we can't reach the minimum
   def query_remote_nodes_until(nodes, _, _, _, min, answers, _)
   when length(nodes) + length(answers) < min do
     :not_enough_nodes
   end
 
-  def query_remote_nodes_until(nodes, module, fun, params, min, _, opts) do
+  # get shit done
+  def query_remote_nodes_until(nodes, module, fun, params, min, answers, opts) do
     {nodes, rest} = Masdb.Node.Communication.select_with_rest(nodes, min)
-    answers =
+    fetch_fun = opts[:fetch_fn] || (fn(nodes, module, fun, params, opts) ->
       Enum.map(nodes, &spawn_query(&1, module, fun, params))
-      |> await_results(opts)
+      |> await_results(opts) end)
 
-    query_remote_nodes_until(rest, module, fun, params, min, opts, answers)
+    answers = answers ++ fetch_fun.(nodes, module, fun, params, opts)
+
+    query_remote_nodes_until(rest, module, fun, params, min, answers, opts)
   end
 
   def query_remote_nodes(nodes, module, fun, params, opts \\ []) do

--- a/lib/masdb/gossip_server.ex
+++ b/lib/masdb/gossip_server.ex
@@ -22,7 +22,7 @@ defmodule Masdb.Gossip.Server do
 
   defp gossip do
     if Masdb.Register.Server.is_synced? do
-      Masdb.Node.DistantSupervisor.query_remote_node(
+      Masdb.Node.DistantSupervisor.query_remote_nodes(
         Enum.take_random(Masdb.Node.list(), Application.get_env(:masdb, :"gossip_size")),
         Masdb.Gossip.Server,
         :received_gossip,

--- a/lib/masdb/gossip_server.ex
+++ b/lib/masdb/gossip_server.ex
@@ -22,7 +22,7 @@ defmodule Masdb.Gossip.Server do
 
   defp gossip do
     Masdb.Node.DistantSupervisor.query_remote_node(
-      Enum.take_random(Masdb.Node.Connection.list(), Application.get_env(:masdb, :"gossip_size")),
+      Enum.take_random(Masdb.Node.list(), Application.get_env(:masdb, :"gossip_size")),
       Masdb.Gossip.Server,
       :received_gossip,
       [Masdb.Register.Server.get_state()]

--- a/lib/masdb/gossip_server.ex
+++ b/lib/masdb/gossip_server.ex
@@ -21,12 +21,14 @@ defmodule Masdb.Gossip.Server do
   end
 
   defp gossip do
-    Masdb.Node.DistantSupervisor.query_remote_node(
-      Enum.take_random(Masdb.Node.list(), Application.get_env(:masdb, :"gossip_size")),
-      Masdb.Gossip.Server,
-      :received_gossip,
-      [Masdb.Register.Server.get_state()]
-    )
+    if Masdb.Node.is_synced? do
+      Masdb.Node.DistantSupervisor.query_remote_node(
+        Enum.take_random(Masdb.Node.list(), Application.get_env(:masdb, :"gossip_size")),
+        Masdb.Gossip.Server,
+        :received_gossip,
+        [Masdb.Register.Server.get_state()]
+      )
+    end
   end
 
   defp schedule_work do

--- a/lib/masdb/gossip_server.ex
+++ b/lib/masdb/gossip_server.ex
@@ -21,7 +21,7 @@ defmodule Masdb.Gossip.Server do
   end
 
   defp gossip do
-    if Masdb.Node.is_synced? do
+    if Masdb.Register.Server.is_synced? do
       Masdb.Node.DistantSupervisor.query_remote_node(
         Enum.take_random(Masdb.Node.list(), Application.get_env(:masdb, :"gossip_size")),
         Masdb.Gossip.Server,

--- a/lib/masdb/initializer.ex
+++ b/lib/masdb/initializer.ex
@@ -1,0 +1,28 @@
+defmodule Masdb.Initializer do
+  def start_link do
+    {:ok, spawn_link(__MODULE__, :initialize_node, [])}
+  end
+
+  def initialize_node do
+    nodes = Masdb.Node.list()
+    {:ok, answers} = Masdb.Node.DistantSupervisor.query_remote_nodes_until(
+      nodes,
+      Masdb.Register.Server,
+      :get_schemas,
+      [],
+      Masdb.Node.Communication.quorum_size(length(nodes))
+    )
+
+    schemas = merge_answers(answers)
+
+    Masdb.Register.Server.initial_add_schemas(schemas)
+
+    :ok
+  end
+
+  def merge_answers(answers, schemas \\ [])
+  def merge_answers([], schemas), do: schemas
+  def merge_answers([{_, schemas}|tail], new_schemas) do
+    merge_answers(tail, Masdb.Register.merge_schemas(schemas, new_schemas))
+  end
+end

--- a/lib/masdb/node.ex
+++ b/lib/masdb/node.ex
@@ -20,6 +20,10 @@ defmodule Masdb.Node do
     GenServer.call(__MODULE__, {:connect, node_name})
   end
 
+  def list do
+    GenServer.call(__MODULE__, :list)
+  end
+
   def handle_call({:start, node_name}, _, _) do
     Masdb.Node.Connection.start(node_name)
     {:reply, :ok, %{node_name: node_name}}
@@ -28,5 +32,9 @@ defmodule Masdb.Node do
   def handle_call({:connect, node_name}, _, state) do
     Masdb.Node.Connection.connect(node_name)
     {:reply, :ok, state}
+  end
+
+  def handle_call(:list, _, state) do
+    {:reply, Masdb.Node.Connection.list(), state}
   end
 end

--- a/lib/masdb/node.ex
+++ b/lib/masdb/node.ex
@@ -2,7 +2,7 @@ defmodule Masdb.Node do
   use GenServer
 
   def start_link do
-    GenServer.start_link(__MODULE__, %{node_name: nil, is_synced: false}, name: __MODULE__)
+    GenServer.start_link(__MODULE__, %{node_name: nil}, name: __MODULE__)
   end
 
   def init(state) do
@@ -24,10 +24,6 @@ defmodule Masdb.Node do
     GenServer.call(__MODULE__, :list)
   end
 
-  def is_synced? do
-    GenServer.call(__MODULE__, :is_synced)
-  end
-
   # Private
   def handle_call({:start, node_name}, _, state) do
     Masdb.Node.Connection.start(node_name)
@@ -41,9 +37,5 @@ defmodule Masdb.Node do
 
   def handle_call(:list, _, state) do
     {:reply, Masdb.Node.Connection.list(), state}
-  end
-
-  def handle_call(:is_synced, _, state) do
-    {:reply, state.is_synced, state}
   end
 end

--- a/lib/masdb/node.ex
+++ b/lib/masdb/node.ex
@@ -2,7 +2,7 @@ defmodule Masdb.Node do
   use GenServer
 
   def start_link do
-    GenServer.start_link(__MODULE__, %{node_name: nil}, name: __MODULE__)
+    GenServer.start_link(__MODULE__, %{node_name: nil, is_synced: false}, name: __MODULE__)
   end
 
   def init(state) do
@@ -24,9 +24,14 @@ defmodule Masdb.Node do
     GenServer.call(__MODULE__, :list)
   end
 
-  def handle_call({:start, node_name}, _, _) do
+  def is_synced? do
+    GenServer.call(__MODULE__, :is_synced)
+  end
+
+  # Private
+  def handle_call({:start, node_name}, _, state) do
     Masdb.Node.Connection.start(node_name)
-    {:reply, :ok, %{node_name: node_name}}
+    {:reply, :ok, %{state | node_name: node_name}}
   end
 
   def handle_call({:connect, node_name}, _, state) do
@@ -36,5 +41,9 @@ defmodule Masdb.Node do
 
   def handle_call(:list, _, state) do
     {:reply, Masdb.Node.Connection.list(), state}
+  end
+
+  def handle_call(:is_synced, _, state) do
+    {:reply, state.is_synced, state}
   end
 end

--- a/lib/masdb/register.ex
+++ b/lib/masdb/register.ex
@@ -42,9 +42,10 @@ defmodule Masdb.Register do
   @type t :: %Masdb.Register{
     stores: list(Masdb.Register.Store.t),
     schemas: list(Masdb.Schema.t),
-    tables: list(Masdb.Register.Table.t)
+    tables: list(Masdb.Register.Table.t),
+    synced: boolean
   }
-  defstruct [stores: [], schemas: [], tables: []]
+  defstruct [stores: [], schemas: [], tables: [], synced: false]
 
   def merge_schemas(olds, news) do
     olds ++ news

--- a/lib/masdb/register_server.ex
+++ b/lib/masdb/register_server.ex
@@ -49,7 +49,7 @@ defmodule Masdb.Register.Server do
     case Masdb.Register.validate_new_schema(state.schemas, schema) do
       :ok ->
         spawn fn ->
-          nodes = Masdb.Node.Connection.list()
+          nodes = Masdb.Node.list()
           a = Masdb.Node.DistantSupervisor.query_remote_node(nodes, Masdb.Register.Server, :remote_add_schema, [schema])
           Masdb.Register.Server.received_add_schema(schema, nodes, a, from)
         end

--- a/lib/masdb/register_server.ex
+++ b/lib/masdb/register_server.ex
@@ -1,5 +1,6 @@
 defmodule Masdb.Register.Server do
   use GenServer
+  require Logger
 
   def start_link(name \\ __MODULE__) do
     GenServer.start_link(__MODULE__, %Masdb.Register{}, name: name)
@@ -29,8 +30,46 @@ defmodule Masdb.Register.Server do
     GenServer.cast(name, {:gossip, gossip})
   end
 
+  def is_synced?(name \\ __MODULE__) do
+    GenServer.call(name, :is_synced)
+  end
+
+  # For testing purposes
+  def force_become_synced(name \\ __MODULE__) do
+    GenServer.call(name, :force_become_synced)
+  end
+
   # private
-  def handle_cast({:received_add_schema, schema, nodes, answers, from}, state) do
+  def handle_call(:get_schemas, _, %{schemas: schemas} = state) do
+    {:reply, schemas, state}
+  end
+
+  def handle_call(:force_become_synced, _, state) do
+    {:reply, :ok, %Masdb.Register{state | synced: true}}
+  end
+
+  def handle_call(params, from, state) do
+    if state.synced do
+      handle_synced_call(params, from, state)
+    else
+      {:reply, :not_synced, state}
+    end
+  end
+
+  def handle_cast({:gossip, %Masdb.Register{schemas: schemas}}, state) do
+    {:noreply, %Masdb.Register{state | schemas: Masdb.Register.merge_schemas(state.schemas, schemas)}}
+  end
+
+  def handle_cast(params, state) do
+    if state.synced do
+      handle_synced_cast(params, state)
+    else
+      Logger.error "The register server received a cast before being synced. " <> inspect(params)
+      {:noreply, state}
+    end
+  end
+
+  def handle_synced_cast({:received_add_schema, schema, nodes, answers, from}, state) do
     if Masdb.Node.Communication.has_quorum?(nodes, answers) do
       GenServer.reply(from, :ok)
       {:noreply, %Masdb.Register{state | schemas: Masdb.Schema.sort([schema | state.schemas])}}
@@ -40,18 +79,15 @@ defmodule Masdb.Register.Server do
     end
   end
 
-  def handle_cast({:gossip, %Masdb.Register{schemas: schemas}}, state) do
-    {:noreply, %Masdb.Register{state | schemas: Masdb.Register.merge_schemas(state.schemas, schemas)}}
-  end
-
-  def handle_call({:add_schema, schema}, from, state) do
+  def handle_synced_call({:add_schema, schema}, from, state) do
     schema = Masdb.Schema.update_timestamp(schema)
     case Masdb.Register.validate_new_schema(state.schemas, schema) do
       :ok ->
+        this = self()
         spawn fn ->
           nodes = Masdb.Node.list()
           a = Masdb.Node.DistantSupervisor.query_remote_node(nodes, Masdb.Register.Server, :remote_add_schema, [schema])
-          Masdb.Register.Server.received_add_schema(schema, nodes, a, from)
+          Masdb.Register.Server.received_add_schema(schema, nodes, a, from, this)
         end
         {:noreply, state}
 
@@ -59,22 +95,18 @@ defmodule Masdb.Register.Server do
     end
   end
 
-  def handle_call({:remote_add_schema, schema}, _, state) do
-    if Masdb.Node.is_synced?() do
-      case Masdb.Register.validate_new_schema(state.schemas, schema) do
-        :ok -> {:reply, :ok, %Masdb.Register{state | schemas: Masdb.Schema.sort([schema | state.schemas])}}
-        error -> {:reply, error, state}
-      end
-    else
-      {:reply, :not_synced, state}
+  def handle_synced_call({:remote_add_schema, schema}, _, state) do
+    case Masdb.Register.validate_new_schema(state.schemas, schema) do
+      :ok -> {:reply, :ok, %Masdb.Register{state | schemas: Masdb.Schema.sort([schema | state.schemas])}}
+      error -> {:reply, error, state}
     end
   end
 
-  def handle_call(:get_schemas, _, %{schemas: schemas} = state) do
-    {:reply, schemas, state}
+  def handle_synced_call(:get_state, _, state) do
+    {:reply, state, state}
   end
 
-  def handle_call(:get_state, _, state) do
-    {:reply, state, state}
+  def handle_synced_call(:is_synced, _, state) do
+    {:reply, state.is_synced, state}
   end
 end

--- a/lib/masdb/register_server.ex
+++ b/lib/masdb/register_server.ex
@@ -60,9 +60,13 @@ defmodule Masdb.Register.Server do
   end
 
   def handle_call({:remote_add_schema, schema}, _, state) do
-    case Masdb.Register.validate_new_schema(state.schemas, schema) do
-      :ok -> {:reply, :ok, %Masdb.Register{state | schemas: Masdb.Schema.sort([schema | state.schemas])}}
-      error -> {:reply, error, state}
+    if Masdb.Node.is_synced?() do
+      case Masdb.Register.validate_new_schema(state.schemas, schema) do
+        :ok -> {:reply, :ok, %Masdb.Register{state | schemas: Masdb.Schema.sort([schema | state.schemas])}}
+        error -> {:reply, error, state}
+      end
+    else
+      {:reply, :not_synced, state}
     end
   end
 

--- a/lib/masdb/register_server.ex
+++ b/lib/masdb/register_server.ex
@@ -86,8 +86,13 @@ defmodule Masdb.Register.Server do
         this = self()
         spawn fn ->
           nodes = Masdb.Node.list()
-          a = Masdb.Node.DistantSupervisor.query_remote_node(nodes, Masdb.Register.Server, :remote_add_schema, [schema])
-          Masdb.Register.Server.received_add_schema(schema, nodes, a, from, this)
+          answers = Masdb.Node.DistantSupervisor.query_remote_nodes(
+            nodes,
+            Masdb.Register.Server,
+            :remote_add_schema,
+            [schema]
+          )
+          Masdb.Register.Server.received_add_schema(schema, nodes, answers, from, this)
         end
         {:noreply, state}
 

--- a/lib/masdb/supervisor.ex
+++ b/lib/masdb/supervisor.ex
@@ -10,7 +10,8 @@ defmodule Masdb.Supervisor do
       worker(Masdb.Node, []),
       worker(Masdb.Node.DistantSupervisor, []),
       worker(Masdb.Register.Server, []),
-      worker(Masdb.Gossip.Server, [])
+      worker(Masdb.Gossip.Server, []),
+      worker(Masdb.Initializer, [], restart: :transient),
     ], strategy: :one_for_one)
   end
 end

--- a/test/communication_test.exs
+++ b/test/communication_test.exs
@@ -43,6 +43,13 @@ defmodule CommunicationTest do
     assert length(rest3) == 2
     assert nodes3 != rest3
   end
+  test "select_with_rest can be asked for more than it has" do
+    node0 = :a
+
+    {nodes0, rest0} = select_with_rest([node0], 2)
+    assert length(nodes0) == 1
+    assert length(rest0) == 0
+  end
 
   test "quorum_size works" do
     assert quorum_size(0) == 0

--- a/test/communication_test.exs
+++ b/test/communication_test.exs
@@ -8,7 +8,7 @@ defmodule CommunicationTest do
     assert select_quorum([node]) == [node]
   end
 
-  test "select_qorum works on normal lists" do
+  test "select_quorum works on normal lists" do
     node0 = Node.self
     node1 = Node.self
     node2 = Node.self
@@ -17,6 +17,31 @@ defmodule CommunicationTest do
     assert length(select_quorum([node0, node1])) == 2
     assert length(select_quorum([node0, node1, node2])) == 2
     assert length(select_quorum([node0, node1, node2, node3])) == 3
+  end
+
+  test "select_with_rest works with list" do
+    node0 = :a
+    node1 = :b
+    node2 = :c
+    node3 = :d
+
+    {nodes0, rest0} = select_with_rest([node0, node1], 1)
+    assert length(nodes0) == 1
+    assert length(rest0) == 1
+    assert nodes0 != rest0
+
+    {nodes1, rest1} = select_with_rest([node0, node1, node2, node3], 1)
+    assert length(nodes1) == 1
+    assert length(rest1) == 3
+
+    {nodes2, rest2} = select_with_rest([node0, node1, node2, node3], 4)
+    assert length(nodes2) == 4
+    assert length(rest2) == 0
+
+    {nodes3, rest3} = select_with_rest([node0, node1, node2, node3], 2)
+    assert length(nodes3) == 2
+    assert length(rest3) == 2
+    assert nodes3 != rest3
   end
 
   test "quorum_size works" do

--- a/test/initializer_test.exs
+++ b/test/initializer_test.exs
@@ -1,0 +1,32 @@
+defmodule InitializerTest do
+  use PowerAssert
+  import Masdb.Initializer
+
+  test "merge_answers can work with only one answer" do
+    answers = ["foo@localhost": [%Masdb.Schema{name: "foo", replication_factor: 2, columns: [%Masdb.Schema.Column{is_pk: true,  name: "c1", type: :int}]}]]
+
+    [%Masdb.Schema{name: name}] = merge_answers(answers)
+    assert name == "foo"
+  end
+
+  test "merge_answers can work on empty answer" do
+    answers = ["foo@localhost": []]
+
+    assert merge_answers(answers) == []
+  end
+
+  test "merge_answers can work with multiple answers" do
+    answers = [
+      "foo@localhost": [%Masdb.Schema{name: "foo", replication_factor: 2, columns: [%Masdb.Schema.Column{is_pk: true,  name: "c1", type: :int}]}],
+      "bar@something": [%Masdb.Schema{name: "bar", replication_factor: 2, columns: [%Masdb.Schema.Column{is_pk: true,  name: "c1", type: :int}]}],
+      "bar@something": [%Masdb.Schema{name: "bar", replication_factor: 2, columns: [%Masdb.Schema.Column{is_pk: true,  name: "c1", type: :int}]}]
+    ]
+
+    result = answers
+    |> merge_answers
+    |> Enum.map(&(&1.name))
+    |> Enum.sort
+
+    assert result == ["bar", "foo"]
+  end
+end

--- a/test/register_server_test.exs
+++ b/test/register_server_test.exs
@@ -8,15 +8,24 @@ defmodule RegisterServerTest do
   end
 
   test "added schemas are ordered", %{server: server} do
+    force_become_synced(server)
     c0 = %Masdb.Schema.Column{is_pk: true,  name: "c1", type: :int}
     s0 = %Masdb.Schema{name: "foo", replication_factor: 0, columns: [c0]}
     s1 = %Masdb.Schema{name: "bar", replication_factor: 0, columns: [c0]}
 
     add_schema(s0, server)
     add_schema(s1, server)
-    result = get_schemas()
+    result = get_schemas(server)
 
     assert Enum.at(result, 0).name == "bar"
     assert Enum.at(result, 1).name == "foo"
+  end
+
+  test "can't add schema if not synced", %{server: server} do
+    c0 = %Masdb.Schema.Column{is_pk: true,  name: "c1", type: :int}
+    s0 = %Masdb.Schema{name: "foo", replication_factor: 0, columns: [c0]}
+
+    assert add_schema(s0, server) == :not_synced
+    assert get_schemas(server) == []
   end
 end


### PR DESCRIPTION
It adds `query_remote_nodes_until` which before a query until the right number of answers are received.

Also, it adds the concept of a uninitialized node. It's realllllly not fool proof, but it will do the job.

If it's too big, I could separete those 2 parts.

Oh, also it syncs the register when a new node joins :)