### PR TITLE
Credo

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -94,7 +94,7 @@
         {Credo.Check.Refactor.ABCSize},
         {Credo.Check.Refactor.CondStatements},
         {Credo.Check.Refactor.CyclomaticComplexity},
-        {Credo.Check.Refactor.FunctionArity},
+        {Credo.Check.Refactor.FunctionArity, false},
         {Credo.Check.Refactor.MatchInCondition},
         {Credo.Check.Refactor.NegatedConditionsInUnless},
         {Credo.Check.Refactor.NegatedConditionsWithElse},

--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,129 @@
+# This file contains the configuration for Credo and you are probably reading
+# this after creating it with `mix credo.gen.config`.
+#
+# If you find anything wrong or unclear in this file, please report an
+# issue on GitHub: https://github.com/rrrene/credo/issues
+#
+%{
+  #
+  # You can have as many configs as you like in the `configs:` field.
+  configs: [
+    %{
+      #
+      # Run any config using `mix credo -C <name>`. If no config name is given
+      # "default" is used.
+      name: "default",
+      #
+      # These are the files included in the analysis:
+      files: %{
+        #
+        # You can give explicit globs or simply directories.
+        # In the latter case `**/*.{ex,exs}` will be used.
+        included: ["lib/", "src/", "web/", "apps/"],
+        excluded: [~r"/_build/", ~r"/deps/"]
+      },
+      #
+      # If you create your own checks, you must specify the source files for
+      # them here, so they can be loaded by Credo before running the analysis.
+      requires: [],
+      #
+      # Credo automatically checks for updates, like e.g. Hex does.
+      # You can disable this behaviour below:
+      check_for_updates: true,
+      #
+      # If you want to enforce a style guide and need a more traditional linting
+      # experience, you can change `strict` to `true` below:
+      strict: false,
+      #
+      # If you want to use uncolored output by default, you can change `color`
+      # to `false` below:
+      color: true,
+      #
+      # You can customize the parameters of any check by adding a second element
+      # to the tuple.
+      #
+      # To disable a check put `false` as second element:
+      #
+      #     {Credo.Check.Design.DuplicatedCode, false}
+      #
+      checks: [
+        {Credo.Check.Consistency.ExceptionNames},
+        {Credo.Check.Consistency.LineEndings},
+        {Credo.Check.Consistency.MultiAliasImportRequireUse},
+        {Credo.Check.Consistency.ParameterPatternMatching},
+        {Credo.Check.Consistency.SpaceAroundOperators},
+        {Credo.Check.Consistency.SpaceInParentheses},
+        {Credo.Check.Consistency.TabsOrSpaces},
+
+        # For some checks, like AliasUsage, you can only customize the priority
+        # Priority values are: `low, normal, high, higher`
+        {Credo.Check.Design.AliasUsage, priority: :low},
+
+        # For others you can set parameters
+
+        # If you don't want the `setup` and `test` macro calls in ExUnit tests
+        # or the `schema` macro in Ecto schemas to trigger DuplicatedCode, just
+        # set the `excluded_macros` parameter to `[:schema, :setup, :test]`.
+        {Credo.Check.Design.DuplicatedCode, excluded_macros: []},
+
+        # You can also customize the exit_status of each check.
+        # If you don't want TODO comments to cause `mix credo` to fail, just
+        # set this value to 0 (zero).
+        {Credo.Check.Design.TagTODO, exit_status: 2},
+        {Credo.Check.Design.TagFIXME},
+
+        {Credo.Check.Readability.FunctionNames},
+        {Credo.Check.Readability.LargeNumbers},
+        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 120},
+        {Credo.Check.Readability.ModuleAttributeNames},
+        {Credo.Check.Readability.ModuleDoc, false},
+        {Credo.Check.Readability.ModuleNames},
+        {Credo.Check.Readability.NoParenthesesWhenZeroArity},
+        {Credo.Check.Readability.ParenthesesInCondition},
+        {Credo.Check.Readability.PredicateFunctionNames},
+        {Credo.Check.Readability.PreferImplicitTry},
+        {Credo.Check.Readability.RedundantBlankLines},
+        {Credo.Check.Readability.Specs, false},
+        {Credo.Check.Readability.StringSigils},
+        {Credo.Check.Readability.TrailingBlankLine},
+        {Credo.Check.Readability.TrailingWhiteSpace},
+        {Credo.Check.Readability.VariableNames},
+        {Credo.Check.Refactor.DoubleBooleanNegation},
+
+        # {Credo.Check.Refactor.CaseTrivialMatches}, # deprecated in 0.4.0
+        {Credo.Check.Refactor.ABCSize},
+        {Credo.Check.Refactor.CondStatements},
+        {Credo.Check.Refactor.CyclomaticComplexity},
+        {Credo.Check.Refactor.FunctionArity},
+        {Credo.Check.Refactor.MatchInCondition},
+        {Credo.Check.Refactor.NegatedConditionsInUnless},
+        {Credo.Check.Refactor.NegatedConditionsWithElse},
+        {Credo.Check.Refactor.Nesting},
+        {Credo.Check.Refactor.PipeChainStart},
+        {Credo.Check.Refactor.UnlessWithElse},
+        {Credo.Check.Refactor.VariableRebinding},
+
+        {Credo.Check.Warning.BoolOperationOnSameValues},
+        {Credo.Check.Warning.IExPry},
+        {Credo.Check.Warning.IoInspect},
+        {Credo.Check.Warning.NameRedeclarationByAssignment},
+        {Credo.Check.Warning.NameRedeclarationByCase},
+        {Credo.Check.Warning.NameRedeclarationByDef},
+        {Credo.Check.Warning.NameRedeclarationByFn},
+        {Credo.Check.Warning.OperationOnSameValues},
+        {Credo.Check.Warning.OperationWithConstantResult},
+        {Credo.Check.Warning.UnusedEnumOperation},
+        {Credo.Check.Warning.UnusedFileOperation},
+        {Credo.Check.Warning.UnusedKeywordOperation},
+        {Credo.Check.Warning.UnusedListOperation},
+        {Credo.Check.Warning.UnusedPathOperation},
+        {Credo.Check.Warning.UnusedRegexOperation},
+        {Credo.Check.Warning.UnusedStringOperation},
+        {Credo.Check.Warning.UnusedTupleOperation},
+
+        # Custom checks can be created using `mix credo.gen.check`.
+        #
+      ]
+    }
+  ]
+}

--- a/lib/masdb/data_map.ex
+++ b/lib/masdb/data_map.ex
@@ -1,7 +1,7 @@
 defmodule Masdb.Data.Val do
   @type time :: Masdb.Timestamp.t
   @type value :: integer | float | boolean | String.t | :unknown
-  
+
   @type t :: %Masdb.Data.Val{
     since_ts: time,
     value: value,
@@ -30,6 +30,8 @@ end
 
 defmodule Masdb.Data.Map do
   use Pipe
+  alias Masdb.Timestamp
+  alias Masdb.Schema
 
   @type schema_name :: String.t
   @type node_id :: String.t
@@ -46,12 +48,12 @@ defmodule Masdb.Data.Map do
   @enforce_keys [:node_id, :last_update_time]
   defstruct [:node_id, :last_update_time, last_sync_time: nil, map: %{}]
 
-  def insert(%Masdb.Data.Map{ node_id: n_id, last_sync_time: l_s_t, map: old_map }, schema, values) do
-    timestamp = Masdb.Timestamp.get_timestamp()
+  def insert(%Masdb.Data.Map{node_id: n_id, last_sync_time: l_s_t, map: old_map}, schema, values) do
+    timestamp = Timestamp.get_timestamp()
     row_id = n_id <> to_string(timestamp.unique_integer)
     old_rows = Map.get(old_map, schema.name, %Masdb.Data.Table{}).rows
-    pks = Masdb.Schema.get_pks(schema)
-    non_nullables = Masdb.Schema.get_non_nullables(schema)
+    pks = Schema.get_pks(schema)
+    non_nullables = Schema.get_non_nullables(schema)
 
     {row_id, pipe_matching({:ok, _},
               {:ok, values}
@@ -97,9 +99,9 @@ defmodule Masdb.Data.Map do
             node_id: node_id,
             last_update_time: timestamp,
             last_sync_time: last_sync_time,
-            map: Map.update(old_map, 
-                            schema_name, 
-                            %Masdb.Data.Table{rows: %{row_id => row}}, 
+            map: Map.update(old_map,
+                            schema_name,
+                            %Masdb.Data.Table{rows: %{row_id => row}},
                             &(%Masdb.Data.Table{rows: Map.put_new(&1.rows, row_id, row)}))
     }}
   end
@@ -128,7 +130,8 @@ defmodule Masdb.Data.Map do
   end
 
   defp normalize_to_vals(values, [key | keys], timestamp) do
-      Map.update!(values, key, &(%Masdb.Data.Val{since_ts: timestamp, value: &1}))
-        |> normalize_to_vals(keys, timestamp)
+    values
+    |> Map.update!(key, &(%Masdb.Data.Val{since_ts: timestamp, value: &1}))
+    |> normalize_to_vals(keys, timestamp)
   end
 end

--- a/lib/masdb/gossip_server.ex
+++ b/lib/masdb/gossip_server.ex
@@ -1,8 +1,10 @@
 defmodule Masdb.Gossip.Server do
   use GenServer
+  alias Masdb.Node.DistantSupervisor
+  alias Masdb.Register
 
   def received_gossip(gossip) do
-    Masdb.Register.Server.received_gossip(gossip)
+    Register.Server.received_gossip(gossip)
   end
 
   def start_link(name \\ __MODULE__) do
@@ -15,14 +17,14 @@ defmodule Masdb.Gossip.Server do
   end
 
   def handle_info(:tick, state) do
-    gossip()
+    perform_gossip()
     schedule_work()
     {:noreply, state}
   end
 
-  defp gossip do
+  defp perform_gossip do
     if Masdb.Register.Server.is_synced? do
-      Masdb.Node.DistantSupervisor.query_remote_nodes(
+      DistantSupervisor.query_remote_nodes(
         Enum.take_random(Masdb.Node.list(), Application.get_env(:masdb, :"gossip_size")),
         Masdb.Gossip.Server,
         :received_gossip,

--- a/lib/masdb/node.ex
+++ b/lib/masdb/node.ex
@@ -1,13 +1,14 @@
 defmodule Masdb.Node do
   use GenServer
+  alias Masdb.Node.Connection
 
   def start_link do
     GenServer.start_link(__MODULE__, %{node_name: nil}, name: __MODULE__)
   end
 
   def init(state) do
-    Masdb.Node.Connection.start(Application.get_env(:masdb, :"node_name"))
-    Masdb.Node.Connection.connect(Application.get_env(:masdb, :"node_to_join"))
+    Connection.start(Application.get_env(:masdb, :"node_name"))
+    Connection.connect(Application.get_env(:masdb, :"node_to_join"))
 
     {:ok, state}
   end
@@ -26,16 +27,16 @@ defmodule Masdb.Node do
 
   # Private
   def handle_call({:start, node_name}, _, state) do
-    Masdb.Node.Connection.start(node_name)
+    Connection.start(node_name)
     {:reply, :ok, %{state | node_name: node_name}}
   end
 
   def handle_call({:connect, node_name}, _, state) do
-    Masdb.Node.Connection.connect(node_name)
+    Connection.connect(node_name)
     {:reply, :ok, state}
   end
 
   def handle_call(:list, _, state) do
-    {:reply, Masdb.Node.Connection.list(), state}
+    {:reply, Connection.list(), state}
   end
 end

--- a/lib/masdb/register.ex
+++ b/lib/masdb/register.ex
@@ -36,6 +36,7 @@ end
 
 defmodule Masdb.Register do
   use Pipe
+  alias Masdb.Schema
 
   @type id :: integer
 
@@ -53,7 +54,7 @@ defmodule Masdb.Register do
     |> Enum.to_list
     |> choose_schemas([])
   end
-  defp choose_schemas([], acc), do: Masdb.Schema.sort(acc)
+  defp choose_schemas([], acc), do: Schema.sort(acc)
   defp choose_schemas([{_, schemas}|tail], acc) do
     schema = Enum.min_by(schemas, fn s -> {s.creation_time, s} end)
     choose_schemas(tail, [schema | acc])
@@ -65,7 +66,7 @@ defmodule Masdb.Register do
   end
 
   defp validate_schema({_, %Masdb.Schema{} = new_schema}) do
-    Masdb.Schema.validate(new_schema)
+    Schema.validate(new_schema)
   end
 
   defp validate_name_or_age({schemas, %Masdb.Schema{name: name} = schema}) do

--- a/lib/masdb/schema.ex
+++ b/lib/masdb/schema.ex
@@ -5,6 +5,8 @@ defmodule Masdb.Schema.Column do
 end
 
 defmodule Masdb.Schema do
+  alias Masdb.Timestamp
+
   # A replication_factor of 0 is considered as `everywhere`
   @type t :: %Masdb.Schema{
     name: String.t,
@@ -13,7 +15,7 @@ defmodule Masdb.Schema do
     creation_time: Masdb.Timestamp.t
   }
   @enforce_keys [:name, :replication_factor]
-  defstruct [:name, :replication_factor, columns: [], creation_time: Masdb.Timestamp.get_timestamp()]
+  defstruct [:name, :replication_factor, columns: [], creation_time: Timestamp.get_timestamp()]
 
   def get_pks(%Masdb.Schema{columns: cols}) do
     Enum.filter_map(cols, fn(c) -> c.is_pk end, &(&1.name))
@@ -24,7 +26,7 @@ defmodule Masdb.Schema do
   end
 
   def update_timestamp(%Masdb.Schema{} = schema) do
-    %Masdb.Schema{schema | creation_time: Masdb.Timestamp.get_timestamp}
+    %Masdb.Schema{schema | creation_time: Timestamp.get_timestamp}
   end
 
   def validate(%Masdb.Schema{replication_factor: f}) when f < 0 do

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,8 @@ defmodule Masdb.Mixfile do
     [
      {:distillery, "~> 1.0"},
      {:power_assert, "~> 0.0.8", only: :test},
-     {:pipe, "~> 0.0.2"}
+     {:pipe, "~> 0.0.2"},
+     {:credo, "== 0.6.1", only: [:dev, :test]},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,6 @@
-%{"distillery": {:hex, :distillery, "1.1.0", "e9943bd29557e9c252a051d8ac4b47e597cd9bf2a74332b8628eab4954eb51d7", [:mix], []},
+%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
+  "credo": {:hex, :credo, "0.6.1", "a941e2591bd2bd2055dc92b810c174650b40b8290459c89a835af9d59ac4a5f8", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
+  "distillery": {:hex, :distillery, "1.1.0", "e9943bd29557e9c252a051d8ac4b47e597cd9bf2a74332b8628eab4954eb51d7", [:mix], []},
   "pipe": {:hex, :pipe, "0.0.2", "eff98a868b426745acef103081581093ff5c1b88100f8ff5949b4a30e81d0d9f", [:mix], []},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
   "power_assert": {:hex, :power_assert, "0.0.8", "8f405cd6a3fdaf4f1963fb649f93a954d1be2b321b2382012b36c550fbad48f5", [:mix], []}}


### PR DESCRIPTION
I added [credo](https://github.com/rrrene/credo) to the project. It's a style analyzer. If we want something more strict we could try [https://github.com/lpil/dogma](dogma) but it seems less maintained. I tweak a little bit the rules to remove the error about `@moduledoc` and other documentation.

What do you think about a static code analyzer?

At the same time I tried to fix our style issues. What do you think about them?
- Try to reduce name collisions with our module and `Kernel`
- When using the pipe operator, I tried to always start by a value
- Rather than using full names, I tried to use alias. This let us understand more easily what are the dependents of a module. I wasn't sure at first, but I want there to read their reasoning https://github.com/rrrene/credo/blob/master/lib/credo/check/design/alias_usage.ex.
