### PR TITLE
Datastore server

### DIFF
--- a/lib/masdb/data_server.ex
+++ b/lib/masdb/data_server.ex
@@ -1,0 +1,48 @@
+defmodule Masdb.Data.Server do
+  use GenServer
+  alias Masdb.Data
+  alias Masdb.Register
+  alias Masdb.Timestamp
+
+  def start_link(register \\ Register.Server, name \\ __MODULE__) do
+    GenServer.start_link(__MODULE__,
+      {
+        register,
+        %Data.Map{
+          node_id: inspect(Node.self),
+          last_update_time: Timestamp.get_timestamp()
+        }},
+      name: name
+    )
+  end
+
+  def init(state) do
+   {:ok, state}
+  end
+
+  def insert(schema_name, values, name \\ __MODULE__) do
+    GenServer.call(name, {:insert, schema_name, values})
+  end
+
+  # private
+  def handle_call(params, from, {register, %Data.Map{}} = state) do
+    # since this is blocking, it could cause issues
+    if Register.Server.is_synced?(register) do
+      handle_synced_call(params, from, state)
+    else
+      {:reply, :not_synced, state}
+    end
+  end
+
+  def handle_synced_call({:insert, schema_name, values}, _, {register, state}) do
+    result =
+      with {:ok, schema} <- Register.Server.get_schema(schema_name, register) do
+        Data.Map.insert(state, schema, values)
+      end
+
+    case result do
+      {:ok, row_id, new_state} -> {:reply, {:ok, row_id}, {register, new_state}}
+      error -> {:reply, error, {register, state}}
+    end
+  end
+end

--- a/lib/masdb/gossip_server.ex
+++ b/lib/masdb/gossip_server.ex
@@ -8,7 +8,7 @@ defmodule Masdb.Gossip.Server do
   end
 
   def start_link(name \\ __MODULE__) do
-    GenServer.start_link(name, [])
+    GenServer.start_link(__MODULE__, [], name: name)
   end
 
   def init([]) do

--- a/lib/masdb/supervisor.ex
+++ b/lib/masdb/supervisor.ex
@@ -10,6 +10,7 @@ defmodule Masdb.Supervisor do
       worker(Masdb.Node, []),
       worker(Masdb.Node.DistantSupervisor, []),
       worker(Masdb.Register.Server, []),
+      worker(Masdb.Data.Server, []),
       worker(Masdb.Gossip.Server, []),
       worker(Masdb.Initializer, [], restart: :transient),
     ], strategy: :one_for_one)

--- a/test/data_server_test.exs
+++ b/test/data_server_test.exs
@@ -1,0 +1,23 @@
+defmodule DataServerTest do
+  use PowerAssert
+  import Masdb.Data.Server
+  alias Masdb.Register
+  alias Masdb.Data
+
+  setup context do
+    {:ok, register} = Register.Server.start_link(context.test)
+    {:ok, data_server} = Masdb.Data.Server.start_link(
+      context.test,
+      String.to_atom(Atom.to_string(context.test) <> " data_server")
+    )
+    Register.Server.force_become_synced(register)
+    [register: register, data_server: data_server]
+  end
+
+  test "insert waits for the register to be synced", context do
+    {:ok, register} = Register.Server.start_link(:foo)
+    {:ok, data_server} = start_link(:foo, :bar)
+
+    assert insert("foo", [], data_server) == :not_synced
+  end
+end

--- a/test/register_server_test.exs
+++ b/test/register_server_test.exs
@@ -1,17 +1,19 @@
 defmodule RegisterServerTest do
   use PowerAssert
   import Masdb.Register.Server
+  alias Masdb.Register
+  alias Masdb.Schema
 
   setup context do
-    {:ok, server} = Masdb.Register.Server.start_link(context.test)
+    {:ok, server} = Register.Server.start_link(context.test)
     {:ok, server: server}
   end
 
   test "added schemas are ordered", %{server: server} do
     force_become_synced(server)
-    c0 = %Masdb.Schema.Column{is_pk: true,  name: "c1", type: :int}
-    s0 = %Masdb.Schema{name: "foo", replication_factor: 0, columns: [c0]}
-    s1 = %Masdb.Schema{name: "bar", replication_factor: 0, columns: [c0]}
+    c0 = %Schema.Column{is_pk: true,  name: "c1", type: :int}
+    s0 = %Schema{name: "foo", replication_factor: 0, columns: [c0]}
+    s1 = %Schema{name: "bar", replication_factor: 0, columns: [c0]}
 
     add_schema(s0, server)
     add_schema(s1, server)
@@ -21,9 +23,23 @@ defmodule RegisterServerTest do
     assert Enum.at(result, 1).name == "foo"
   end
 
+  test "get_schema can return a schema or an error", %{server: server} do
+    force_become_synced(server)
+    c0 = %Schema.Column{is_pk: true,  name: "c1", type: :int}
+    s0 = %Schema{name: "foo", replication_factor: 0, columns: [c0]}
+    s1 = %Schema{name: "bar", replication_factor: 0, columns: [c0]}
+
+    add_schema(s0, server)
+    add_schema(s1, server)
+
+    assert elem(get_schema("foo", server), 1).name == "foo"
+    assert elem(get_schema("bar", server), 1).name == "bar"
+    assert get_schema("baz", server) == :not_found
+  end
+
   test "can't add schema if not synced", %{server: server} do
-    c0 = %Masdb.Schema.Column{is_pk: true,  name: "c1", type: :int}
-    s0 = %Masdb.Schema{name: "foo", replication_factor: 0, columns: [c0]}
+    c0 = %Schema.Column{is_pk: true,  name: "c1", type: :int}
+    s0 = %Schema{name: "foo", replication_factor: 0, columns: [c0]}
 
     assert add_schema(s0, server) == :not_synced
     assert get_schemas(server) == []


### PR DESCRIPTION
Adds the basic Genserver keeping the state.

Interesting syntax I found : with (http://learningelixir.joekain.com/learning-elixir-with/). This kinda replace the Pipe library. It's more verbose, but it has the advantage that every function can have a different return form.