### PR TITLE
Dialyzer

### DIFF
--- a/lib/masdb/data_map.ex
+++ b/lib/masdb/data_map.ex
@@ -29,7 +29,6 @@ defmodule Masdb.Data.Table do
 end
 
 defmodule Masdb.Data.Map do
-  use Pipe
   alias Masdb.Timestamp
   alias Masdb.Schema
 

--- a/lib/masdb/data_map.ex
+++ b/lib/masdb/data_map.ex
@@ -55,13 +55,13 @@ defmodule Masdb.Data.Map do
     pks = Schema.get_pks(schema)
     non_nullables = Schema.get_non_nullables(schema)
 
-    pipe_matching({:ok, _, _},
+    with :ok <- validate_with_schema(row_id, values, schema),
+         :ok <- validate_nullable_referenced(row_id, values, non_nullables),
+         :ok <- validate_pk_uniqueness(row_id, values, old_rows, pks),
+         {:ok, values} <- normalize_to_row(row_id, values, timestamp),
+         {:ok, values} <- put_new_row(row_id, values, schema.name, n_id, l_s_t, old_map, timestamp) do
       {:ok, row_id, values}
-      |> validate_with_schema(schema)
-      |> validate_nullable_referenced(non_nullables)
-      |> validate_pk_uniqueness(old_rows, pks)
-      |> normalize_to_row(timestamp)
-      |> put_new_row(schema.name, n_id, l_s_t, old_map, timestamp))
+    end
   end
 
   def select(%Masdb.Data.Map{map: data_map}, schema_name, columns, selector \\ :all) do
@@ -71,45 +71,42 @@ defmodule Masdb.Data.Map do
     end
   end
 
-  defp validate_with_schema({:ok, row_id, values}, schema) do
+  defp validate_with_schema(row_id, values, schema) do
     keys = Map.keys(values)
     case length(keys) do
-      0 -> {:cannot_insert_empty_row, row_id, values}
-      _ -> {validate_col_exists(keys, schema), row_id, values}
+      0 -> :cannot_insert_empty_row
+      _ -> validate_col_exists(keys, schema)
     end
   end
 
-  defp validate_nullable_referenced(values, []) do
-    values
-  end
-
-  defp validate_nullable_referenced({:ok, row_id, values}, [nn_nullable | tail]) do
+  defp validate_nullable_referenced(row_id, values, []), do: :ok
+  defp validate_nullable_referenced(row_id, values, [nn_nullable | tail]) do
     case Map.get(values, nn_nullable) do
-      nil -> {:non_nullable_not_referenced, row_id, values}
-        _ -> validate_nullable_referenced({:ok, row_id, values}, tail)
+      nil -> :non_nullable_not_referenced
+        _ -> validate_nullable_referenced(row_id, values, tail)
     end
   end
 
-  defp validate_pk_uniqueness({:ok, row_id, values}, rows, pks) do
+  defp validate_pk_uniqueness(row_id, values, rows, pks) do
     case Enum.find(Map.values(rows), &(row_has_same_pk?(&1, values, pks))) do
-      nil -> {:ok, row_id, values}
-        _ -> {:duplicate_pk, row_id, values}
+      nil -> :ok
+        _ -> :duplicate_pk
     end
   end
 
-  defp normalize_to_row({:ok, row_id, values}, timestamp) do
-    {:ok, row_id, %Masdb.Data.Row{columns: normalize_to_vals(values, Map.keys(values), timestamp)}}
+  defp normalize_to_row(row_id, values, timestamp) do
+    {:ok, %Masdb.Data.Row{columns: normalize_to_vals(values, Map.keys(values), timestamp)}}
   end
 
-  defp put_new_row({:ok, row_id, row}, schema_name, node_id, last_sync_time, old_map, timestamp) do
-    {:ok, row_id, %Masdb.Data.Map{
-                    node_id: node_id,
-                    last_update_time: timestamp,
-                    last_sync_time: last_sync_time,
-                    map: Map.update(old_map,
-                                    schema_name,
-                                    %Masdb.Data.Table{rows: %{row_id => row}},
-                                    &(%Masdb.Data.Table{rows: Map.put_new(&1.rows, row_id, row)}))
+  defp put_new_row(row_id, row, schema_name, node_id, last_sync_time, old_map, timestamp) do
+    {:ok, %Masdb.Data.Map{
+        node_id: node_id,
+        last_update_time: timestamp,
+        last_sync_time: last_sync_time,
+        map: Map.update(old_map,
+          schema_name,
+          %Masdb.Data.Table{rows: %{row_id => row}},
+          &(%Masdb.Data.Table{rows: Map.put_new(&1.rows, row_id, row)}))
     }}
   end
 

--- a/lib/masdb/register.ex
+++ b/lib/masdb/register.ex
@@ -35,7 +35,6 @@ defmodule Masdb.Register.Store do
 end
 
 defmodule Masdb.Register do
-  use Pipe
   alias Masdb.Schema
 
   @type id :: integer
@@ -61,15 +60,16 @@ defmodule Masdb.Register do
   end
 
   def validate_new_schema(schemas, new_schema) do
-    pipe_matching {schemas, new_schema}, :ok,
-      :ok |> validate_schema |> validate_name_or_age
+    with :ok <- validate_schema(schemas, new_schema) do
+      validate_name_or_age(schemas, new_schema)
+    end
   end
 
-  defp validate_schema({_, %Masdb.Schema{} = new_schema}) do
+  defp validate_schema(_, %Masdb.Schema{} = new_schema) do
     Schema.validate(new_schema)
   end
 
-  defp validate_name_or_age({schemas, %Masdb.Schema{name: name} = schema}) do
+  defp validate_name_or_age(schemas, %Masdb.Schema{name: name} = schema) do
     case validate_name(Enum.map(schemas, &(&1.name)), name) do
       :ok -> :ok
       error ->

--- a/mix.exs
+++ b/mix.exs
@@ -23,6 +23,7 @@ defmodule Masdb.Mixfile do
      {:power_assert, "~> 0.0.8", only: :test},
      {:pipe, "~> 0.0.2"},
      {:credo, "== 0.6.1", only: [:dev, :test], runtime: false},
+     {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,15 @@ defmodule Masdb.Mixfile do
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps()]
+     deps: deps(),
+     dialyzer: [flags: [
+                   :error_handling,
+                   :race_conditions,
+                   :underspecs,
+                   :no_unused,
+                   :unknown,
+                 ]],
+    ]
   end
 
   def application do
@@ -21,7 +29,6 @@ defmodule Masdb.Mixfile do
     [
      {:distillery, "~> 1.0"},
      {:power_assert, "~> 0.0.8", only: :test},
-     {:pipe, "~> 0.0.2"},
      {:credo, "== 0.6.1", only: [:dev, :test], runtime: false},
      {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
   "credo": {:hex, :credo, "0.6.1", "a941e2591bd2bd2055dc92b810c174650b40b8290459c89a835af9d59ac4a5f8", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
+  "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], []},
   "distillery": {:hex, :distillery, "1.1.0", "e9943bd29557e9c252a051d8ac4b47e597cd9bf2a74332b8628eab4954eb51d7", [:mix], []},
   "pipe": {:hex, :pipe, "0.0.2", "eff98a868b426745acef103081581093ff5c1b88100f8ff5949b4a30e81d0d9f", [:mix], []},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},

--- a/test/data_map_test.exs
+++ b/test/data_map_test.exs
@@ -18,7 +18,7 @@ defmodule DataMapTest do
       map: %{"foo" => %Masdb.Data.Table{}}
     }
 
-    {flag, _, _} = Masdb.Data.Map.insert(map, inserted_schema, inserted_value)
+    flag = Masdb.Data.Map.insert(map, inserted_schema, inserted_value)
     assert flag == :cannot_insert_empty_row
   end
 
@@ -39,7 +39,7 @@ defmodule DataMapTest do
       map: %{"foo" => %Masdb.Data.Table{}}
     }
 
-    {flag, _, _} = Masdb.Data.Map.insert(map, inserted_schema, inserted_value)
+    flag = Masdb.Data.Map.insert(map, inserted_schema, inserted_value)
     assert flag == :col_doesnt_exists
   end
 
@@ -66,7 +66,7 @@ defmodule DataMapTest do
                                                         }}}}}
     }
 
-    {flag, _, _} = Masdb.Data.Map.insert(map, inserted_schema, inserted_value)
+    flag = Masdb.Data.Map.insert(map, inserted_schema, inserted_value)
     assert flag == :duplicate_pk
   end
 
@@ -115,7 +115,7 @@ defmodule DataMapTest do
       map: %{"foo" => %Masdb.Data.Table{}}
     }
 
-    {flag, _, _} = Masdb.Data.Map.insert(map, inserted_schema, inserted_value)
+    flag = Masdb.Data.Map.insert(map, inserted_schema, inserted_value)
     assert flag == :non_nullable_not_referenced
   end
 


### PR DESCRIPTION
This is a proposal, feel free to reject it.

In my next PR, I would like to use `@spec`. At the same time, I though that adding dialyzer would be a great idea to validate the spec. But, dialyzer had a hard time validating our usage of the pipe module. I replaced them by `with`. I think it's a little by more code for the caller, but it's more clear. Also, it let the callee have any signature.

If you want to run dializer, you can simply `mix dialyzer`.

What's your opinion on that?