### PR TITLE
Data api

### DIFF
--- a/lib/masdb/data_api.ex
+++ b/lib/masdb/data_api.ex
@@ -1,19 +1,33 @@
 defmodule Masdb.Data.API do
   alias Masdb.Data
   alias Masdb.Node.DistantSupervisor
+  alias Masdb.Node.Communication
 
+  @spec insert(String.t, map, atom, keyword) :: {:ok, integer} | atom
   def insert(schema_name, values, consistency, opts \\ [])
   def insert(schema_name, values, :quorum, opts) do
-    with {:ok, local_row_id} <- Data.Server.insert(schema_name, values),
-         {:ok, remote_answer} <- DistantSupervisor.query_remote_nodes_until() do
-      {:ok, local_row_id, remote_answer}
+    with {:ok, local_row_id} <- Data.Server.insert(schema_name, values, opts[:data_server]),
+         nodes <- opts[:nodes] || Masdb.Node.list(),
+         {:ok, remote_answers} <- DistantSupervisor.query_remote_nodes_until(nodes, Masdb.Data.Server, :insert,
+           [schema_name, values], Communication.quorum_size(length(nodes)), [], opts),
+         :ok <- validate_remote_insert(remote_answers) do
+      {:ok, local_row_id}
     end
 
   end
-  def insert(schema_name, values, consistency, opts) when consistency in [:unique, :multiple, :quorum, :all] do
+  def insert(_, _, consistency, _) when consistency in [:unique, :multiple, :quorum, :all] do
     :not_implemented
   end
   def insert(_, _, _, _) do
     :unacceptable_consistency_level
+  end
+
+  @spec validate_remote_insert(keyword) :: :ok | atom
+  def validate_remote_insert([]), do: :ok
+  def validate_remote_insert([{_, head}|tail]) do
+    case head do
+      {:ok, _} -> validate_remote_insert(tail)
+      _ -> :refused_modification
+    end
   end
 end

--- a/lib/masdb/data_api.ex
+++ b/lib/masdb/data_api.ex
@@ -1,0 +1,19 @@
+defmodule Masdb.Data.API do
+  alias Masdb.Data
+  alias Masdb.Node.DistantSupervisor
+
+  def insert(schema_name, values, consistency, opts \\ [])
+  def insert(schema_name, values, :quorum, opts) do
+    with {:ok, local_row_id} <- Data.Server.insert(schema_name, values),
+         {:ok, remote_answer} <- DistantSupervisor.query_remote_nodes_until() do
+      {:ok, local_row_id, remote_answer}
+    end
+
+  end
+  def insert(schema_name, values, consistency, opts) when consistency in [:unique, :multiple, :quorum, :all] do
+    :not_implemented
+  end
+  def insert(_, _, _, _) do
+    :unacceptable_consistency_level
+  end
+end

--- a/lib/masdb/data_api.ex
+++ b/lib/masdb/data_api.ex
@@ -6,7 +6,8 @@ defmodule Masdb.Data.API do
   @spec insert(String.t, map, atom, keyword) :: {:ok, integer} | atom
   def insert(schema_name, values, consistency, opts \\ [])
   def insert(schema_name, values, :quorum, opts) do
-    with {:ok, local_row_id} <- Data.Server.insert(schema_name, values, opts[:data_server]),
+    data_server = opts[:data_server] || Data.Server
+    with {:ok, local_row_id} <- Data.Server.insert(schema_name, values, data_server),
          nodes <- opts[:nodes] || Masdb.Node.list(),
          {:ok, remote_answers} <- DistantSupervisor.query_remote_nodes_until(nodes, Masdb.Data.Server, :insert,
            [schema_name, values], Communication.quorum_size(length(nodes)), [], opts),

--- a/lib/masdb/data_server.ex
+++ b/lib/masdb/data_server.ex
@@ -20,6 +20,7 @@ defmodule Masdb.Data.Server do
    {:ok, state}
   end
 
+  @spec insert(String.t, keyword, atom) :: {:ok, integer} | atom
   def insert(schema_name, values, name \\ __MODULE__) do
     GenServer.call(name, {:insert, schema_name, values})
   end

--- a/lib/masdb/distant_supervisor.ex
+++ b/lib/masdb/distant_supervisor.ex
@@ -13,6 +13,7 @@ defmodule Masdb.Node.DistantSupervisor do
     Enum.find(tasks, fn t -> elem(t, 1).ref == ref end)
   end
 
+  @spec query_remote_nodes_until([atom], atom, atom, [any], integer, keyword, keyword) :: {:ok, keyword} | atom
   def query_remote_nodes_until(nodes, module, fun, params, min, answers \\ [], opts \\ [])
   # enough responses
   def query_remote_nodes_until(_, _, _, _, min, answers, _)

--- a/test/data_api_test.exs
+++ b/test/data_api_test.exs
@@ -1,0 +1,45 @@
+defmodule DataAPITest do
+  use PowerAssert
+  import Masdb.Data.API
+  alias Masdb.Schema
+  alias Masdb.Register
+
+  setup context do
+    {:ok, register} = Register.Server.start_link(context.test)
+    {:ok, data_server} = Masdb.Data.Server.start_link(
+      context.test,
+      String.to_atom(Atom.to_string(context.test) <> " data_server")
+    )
+    Register.Server.force_become_synced(register)
+    [register: register, data_server: data_server]
+  end
+
+  test "insert can only be called with predefined consistency levels",
+    %{register: register, data_server: data_server} do
+    c0 = %Schema.Column{is_pk: true,  name: "c1", type: :int}
+    s0 = %Schema{name: "foo", replication_factor: 0, columns: [c0]}
+    Register.Server.add_schema(s0, register)
+
+    levels = [unique: 0, multiple: 1, quorum: 2, all: 3]
+
+    for {l, i} <- levels, do: insert("foo", %{"c1" => i}, l)
+
+    assert insert("foo", %{"c1" => 0}, :foo) == :unacceptable_consistency_level
+  end
+
+  test "insert :unique doesn't perform a remote query",
+    %{register: register, data_server: data_server} do
+    c0 = %Schema.Column{is_pk: true,  name: "c1", type: :int}
+    s0 = %Schema{name: "foo", replication_factor: 0, columns: [c0]}
+    Register.Server.add_schema(s0, register)
+    this = self()
+    opts = [
+      timeout: 10,
+      fetch_fn: fn(_, _, _, _, _) -> send this, :fetched end
+    ]
+
+    insert("foo", %{"c1" => 0}, :unique)
+
+    refute_received :fetched
+  end
+end

--- a/test/data_api_test.exs
+++ b/test/data_api_test.exs
@@ -20,15 +20,22 @@ defmodule DataAPITest do
     s0 = %Schema{name: "foo", replication_factor: 0, columns: [c0]}
     Register.Server.add_schema(s0, register)
 
+    opts = [
+      timeout: 10,
+      nodes: [],
+      data_server: data_server,
+      fetch_fn: fn(_, _, _, _, _) -> [] end
+    ]
+
     levels = [unique: 0, multiple: 1, quorum: 2, all: 3]
 
-    for {l, i} <- levels, do: insert("foo", %{"c1" => i}, l)
+    for {l, i} <- levels, do: insert("foo", %{"c1" => i}, l, opts)
 
     assert insert("foo", %{"c1" => 0}, :foo) == :unacceptable_consistency_level
   end
 
   test "insert :unique doesn't perform a remote query",
-    %{register: register, data_server: data_server} do
+    %{register: register} do
     c0 = %Schema.Column{is_pk: true,  name: "c1", type: :int}
     s0 = %Schema{name: "foo", replication_factor: 0, columns: [c0]}
     Register.Server.add_schema(s0, register)
@@ -38,8 +45,45 @@ defmodule DataAPITest do
       fetch_fn: fn(_, _, _, _, _) -> send this, :fetched end
     ]
 
-    insert("foo", %{"c1" => 0}, :unique)
+    insert("foo", %{"c1" => 0}, :unique, opts)
 
     refute_received :fetched
+  end
+
+  test "insert :quorum can succeed",
+    %{register: register, data_server: data_server} do
+    c0 = %Schema.Column{is_pk: true,  name: "c1", type: :int}
+    s0 = %Schema{name: "foo", replication_factor: 0, columns: [c0]}
+    Register.Server.add_schema(s0, register)
+
+    opts = [
+      timeout: 10,
+      nodes: [:foo, :bar, :baz, :wow, :idea],
+      data_server: data_server,
+      fetch_fn: fn(_, _, _, _, _) -> [foo: {:ok, 1}, bar: {:ok, 1}, baz: {:ok, 1}] end
+    ]
+
+    {flag, _} = insert("foo", %{"c1" => 0}, :quorum, opts)
+
+    assert flag == :ok
+  end
+
+  test "insert :quorum fails when the schema doesn't exist",
+    %{data_server: data_server} do
+    opts = [
+      timeout: 10,
+      nodes: [:foo, :bar, :baz, :wow, :idea],
+      data_server: data_server,
+      fetch_fn: fn(_, _, _, _, _) -> [foo: {:ok, 1}, bar: {:ok, 1}, baz: {:ok, 1}] end
+    ]
+
+    assert insert("foo", %{"c1" => 0}, :quorum, opts) == :not_found
+  end
+
+  test "validate_remote_insert should only pass if all success" do
+    assert validate_remote_insert([]) == :ok
+    assert validate_remote_insert([a: {:ok, 1}]) == :ok
+    assert validate_remote_insert([a: {:ok, 1}, b: {:ok, 1}]) == :ok
+    assert validate_remote_insert([a: {:ok, 1}, b: :cannot_insert_empty_row]) == :refused_modification
   end
 end

--- a/test/data_server_test.exs
+++ b/test/data_server_test.exs
@@ -6,7 +6,7 @@ defmodule DataServerTest do
 
   setup context do
     {:ok, register} = Register.Server.start_link(context.test)
-    {:ok, data_server} = Masdb.Data.Server.start_link(
+    {:ok, data_server} = Data.Server.start_link(
       context.test,
       String.to_atom(Atom.to_string(context.test) <> " data_server")
     )
@@ -14,8 +14,8 @@ defmodule DataServerTest do
     [register: register, data_server: data_server]
   end
 
-  test "insert waits for the register to be synced", context do
-    {:ok, register} = Register.Server.start_link(:foo)
+  test "insert waits for the register to be synced" do
+    {:ok, _} = Register.Server.start_link(:foo)
     {:ok, data_server} = start_link(:foo, :bar)
 
     assert insert("foo", [], data_server) == :not_synced


### PR DESCRIPTION
Adds the `insert` with quorum. It uses the dialyzer PR. By playing with it, I found an issue in `validate_pk_uniqueness`. I'll do another PR to fix it.